### PR TITLE
_get_sequence() can return a number much larger than 65535

### DIFF
--- a/pycomm/cip/cip_base.py
+++ b/pycomm/cip/cip_base.py
@@ -543,7 +543,7 @@ class Base(object):
         if Base._sequence < 65535:
             Base._sequence += 1
         else:
-            Base._sequence = getpid()
+            Base._sequence = getpid() % 65535
         return Base._sequence
 
     def nop(self):


### PR DESCRIPTION
There are many calls throughout the program to pack_uint(Base._get_sequence()).  If _get_sequence() returned the PID, the PID can be much larger than 65535, causing an uncaught exception.  This can be resolved by calling MOD 65535 on the result of getpid()